### PR TITLE
Bump the version of Atlas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM maven:3.5.4-jdk-8 AS stage-atlas
 
-ENV ATLAS_VERSION 2.0.0
+ENV ATLAS_VERSION "3.0.0-e44eb9d64"
 ENV TARBALL apache-atlas-${ATLAS_VERSION}-sources.tar.gz
 ENV	ATLAS_REPO      https://dist.apache.org/repos/dist/release/atlas/${ATLAS_VERSION}/${TARBALL}
 ENV	MAVEN_OPTS	"-Xms2g -Xmx2g"


### PR DESCRIPTION
In order to include the latest fixes, bumps the version to  Atlas 3 [Snapshot]